### PR TITLE
Added container shutdown logic

### DIFF
--- a/config/compose.yaml.default
+++ b/config/compose.yaml.default
@@ -38,12 +38,10 @@ services:
     restart: on-failure # Restart the Windows VM if the exit code indicates an error.
     volumes:
       - data:/storage:Z # Mount volume 'data' to use as Windows 'C:' drive.
-      - ${HOME}/Public:/shared:z # Mount Linux user home directory @ '\\host.lan\Data'.
+      #- ${HOME}:/shared:z # Mount Linux user home directory @ '\\host.lan\Data'.
       #- /path/to/second/hard/disk:/storage2 # Uncomment to mount the second hard disk within the Windows VM. Ensure 'DISK2_SIZE' is specified above.
       - ./oem:/oem:Z # Enables automatic post-install execution of 'oem/install.bat'
-      #- /home/user/Win11.iso:/boot.iso # Uncomment to use a custom Windows ISO. If specified, 'VERSION' (e.g. 'tiny11') will be ignored. Also, use windows 10 iot ltsc, it is much lighter and works fine, with me at least
-      - /dev/kvm # Enable KVM.
-      - /dev/net/tun # Enable tuntap
+      #- /home/user/Win11.iso:/boot.iso # Uncomment to use a custom Windows ISO. If specified, 'VERSION' (e.g. 'tiny11') will be ignored.
       # Custom ISO doesn't work if stored on btrfs formatted drive!
       # SELinux: ":Z" means the volume will only be available in this container, ":z" means the volume can also be accessed by other containers
     devices:

--- a/config/compose.yaml.default
+++ b/config/compose.yaml.default
@@ -38,10 +38,12 @@ services:
     restart: on-failure # Restart the Windows VM if the exit code indicates an error.
     volumes:
       - data:/storage:Z # Mount volume 'data' to use as Windows 'C:' drive.
-      #- ${HOME}:/shared:z # Mount Linux user home directory @ '\\host.lan\Data'.
+      - ${HOME}/Public:/shared:z # Mount Linux user home directory @ '\\host.lan\Data'.
       #- /path/to/second/hard/disk:/storage2 # Uncomment to mount the second hard disk within the Windows VM. Ensure 'DISK2_SIZE' is specified above.
       - ./oem:/oem:Z # Enables automatic post-install execution of 'oem/install.bat'
-      #- /home/user/Win11.iso:/boot.iso # Uncomment to use a custom Windows ISO. If specified, 'VERSION' (e.g. 'tiny11') will be ignored.
+      #- /home/user/Win11.iso:/boot.iso # Uncomment to use a custom Windows ISO. If specified, 'VERSION' (e.g. 'tiny11') will be ignored. Also, use windows 10 iot ltsc, it is much lighter and works fine, with me at least
+      - /dev/kvm # Enable KVM.
+      - /dev/net/tun # Enable tuntap
       # Custom ISO doesn't work if stored on btrfs formatted drive!
       # SELinux: ":Z" means the volume will only be available in this container, ":z" means the volume can also be accessed by other containers
     devices:

--- a/linoffice.sh
+++ b/linoffice.sh
@@ -735,6 +735,7 @@ function waRunCommand() {
         printf "\033[1m./linoffice.sh reset\033[0m -> kills all FreeRDP processes, cleans up Office lock files, and reboots the Windows VM\n"
         printf "\033[1m./linoffice.sh cleanup [--full|--reset]\033[0m -> cleans up Office lock files (such as ~\$file.xlsx) in the home folder and removable media; --full cleans all files regardless of creation date, --reset resets the last cleanup timestamp\n"
         printf "\033[1m./linoffice.sh --startcontainer\033[0m -> will start the Windows container if it is not running and not execute anything else\n"
+        printf "\033[1m./linoffice.sh --stopcontainer\033[0m -> shuts down the Windows container completely\n"
         exit 0
     fi
 
@@ -1044,6 +1045,39 @@ function waCheckIdle() {
 }
 
 ### MAIN LOGIC ###
+
+# Handle --stopcontainer command first and exit
+if [[ "$1" == "--stopcontainer" ]]; then
+    dprint "SHUTTING DOWN CONTAINER"
+    echo "Attempting graceful shutdown of LinOffice container..."
+
+    # Check the current status of the container
+    CONTAINER_STATUS=$(podman inspect --format='{{.State.Status}}' "$CONTAINER_NAME" 2>/dev/null)
+
+    # If the container is paused, it must be un-paused first to shut down cleanly
+    if [[ "$CONTAINER_STATUS" == "paused" ]]; then
+        echo "Container is paused, unpausing to allow clean shutdown..."
+        "$COMPOSE_COMMAND" --file "$COMPOSE_PATH" unpause &>/dev/null
+        sleep 2 # Give it a moment to wake up before stopping
+    fi
+
+    # Now, if the container is running (or was just un-paused), stop it
+    if [[ "$CONTAINER_STATUS" == "running" || "$CONTAINER_STATUS" == "paused" ]]; then
+        echo "Sending stop command... (this may take up to 2 minutes)"
+        # Use podman-compose stop, which respects the grace period in the yaml
+        "$COMPOSE_COMMAND" --file "$COMPOSE_PATH" stop &>/dev/null
+    else
+        echo "Container is not running."
+    fi
+
+    echo "Cleaning up all resources..."
+    # Finally, run 'down' to ensure the stopped container is fully removed.
+    "$COMPOSE_COMMAND" --file "$COMPOSE_PATH" down --remove-orphans &>/dev/null
+
+    echo "LinOffice has been shut down."
+    exit 0
+fi
+
 dprint "START"
 dprint "SCRIPT_DIR: ${SCRIPT_DIR_PATH}"
 dprint "SCRIPT_ARGS: ${*}"


### PR DESCRIPTION
Description:
This pull request introduces a new `--stopcontainer` flag to provide users with a reliable, one-step method for completely shutting down the LinOffice container and freeing all system resources.

Problem Solved:
Currently, there is no simple command to fully stop and remove the container. Users have to manually run `podman-compose down`, which can fail to terminate the underlying QEMU process if it doesn't shut down within the grace period, leaving an orphaned process.

Solution:
This new command adds robust shutdown logic that:
    1. Checks if the container is paused and un-pauses it first.
    2. Issues a graceful stop command, respecting the `stop_grace_period`.
    3. Runs `podman-compose down` to remove the stopped container and clean up all associated resources.

This ensures a clean and complete shutdown every time, preventing orphaned processes and resource leaks.