### PR TITLE
Update setup.sh and GUI

### DIFF
--- a/gui/installer/installer.py
+++ b/gui/installer/installer.py
@@ -181,6 +181,13 @@ class Wizard(QWidget):
                     percentage = min(87.5, self.progress_bar.value())  # Cap at 87.5% for steps > 8
                 self.progress_bar.setValue(int(percentage))
 
+            # Handle Windows download percentage
+            download_match = re.search(r'Downloading Windows (10|11): (\d+)%', clean_line)
+            if download_match:
+                win_percent = int(download_match.group(2))
+                # Map to range 37–50%
+                mapped_percent = 37 + (win_percent / 100) * (50 - 37)
+                self.progress_bar.setValue(int(mapped_percent))
         # Check if process has finished and exited successfully
         if self.process.state() == QProcess.NotRunning:
             if self.process.exitStatus() == QProcess.NormalExit and self.process.exitCode() == 0:


### PR DESCRIPTION
Previously, the download progress for the Windows image was only updated in large 10% increments (10%, 20%, 30%, etc.). This could make the installer appear frozen or unresponsive, especially on slower connections. There was also no indication of the current download speed, fine-grained progress, or which version of Windows (10 or 11) was being downloaded.

Detailed Progress: The download progress is now displayed with 1% granularity.
Speed Display: The current download speed is now shown (e.g., Speed: XXXMB/s).
Windows Version Display: The script now detects and displays whether Windows 10 or 11 is being downloaded. This is important as some older hardware may not be compatible with Windows 11 under QEMU, so informing the user is helpful.
GUI Integration: When installing via the GUI, this detailed progress is now correctly reflected in the GUI's action log and updates the main progress bar smoothly between 37% and 50% (during stage 4 of the installation).
<img width="878" height="559" alt="preview" src="https://github.com/user-attachments/assets/f4a649e2-3c69-41e7-b3e6-55f3821c0ceb" />