### PR TITLE
fix false positive for flathub remote detection

### DIFF
--- a/quickstart.sh
+++ b/quickstart.sh
@@ -207,7 +207,8 @@ install_freerdp_flatpak() {
     try_install_any flatpak || { echo "Failed to install flatpak"; exit 1; }
   fi
 
-  if ! flatpak remote-list | grep -q flathub; then
+# make sure to specifically detect flathub user, not flathub system
+  if ! flatpak remote-list | grep -q 'flathub.*user'; then
     flatpak remote-add --if-not-exists --user flathub https://dl.flathub.org/repo/flathub.flatpakrepo
   fi
 


### PR DESCRIPTION
on systems that have `flathub system` available already, the --user remote doesn't get added

```bash
$ flatpak remote-list
Name    Options
flathub system,filtered
```

this bugfix updates the check to explicitly look for the --user remote