### PR TITLE
fix: de-prioritize xfreerdp detection in favor of xfreerdp3

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -139,10 +139,7 @@ function clear_progress() {
 # Function to detect and set the FreeRDP command
 function detect_freerdp_command() {
     # Set FREERDP_COMMAND to the first available FreeRDP command (xfreerdp, xfreerdp3, or flatpak)
-    if command -v xfreerdp &>/dev/null; then
-        FREERDP_COMMAND="xfreerdp"
-        return
-    fi
+    # check xfreerdp3 before xfreerdp, some systems have both installed. e.g. SteamOS has outdated xfreerdp, but also has xfreerdp3 installed
     if command -v xfreerdp3 &>/dev/null; then
         FREERDP_COMMAND="xfreerdp3"
         return
@@ -152,6 +149,10 @@ function detect_freerdp_command() {
             FREERDP_COMMAND="flatpak run --command=xfreerdp com.freerdp.FreeRDP"
             return
         fi
+    fi
+    if command -v xfreerdp &>/dev/null; then
+        FREERDP_COMMAND="xfreerdp"
+        return
     fi
     FREERDP_COMMAND="" # Not found
 }


### PR DESCRIPTION
bugfix for systems that ship an outdated xfreerdp alongside xfreerdp3