### PR TITLE
fixed interpreter detection, when podman-compose shebang contains space

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -161,7 +161,7 @@ validate_podman_compose() {
   shebang=$(head -n1 "$resolved" 2>/dev/null || true)
   if [[ "$shebang" == "#!"* ]]; then
     local interpreter="${shebang#\#!}"
-    interpreter=${interpreter%% *}
+    read -r interpreter _ <<<"${interpreter}"
     if [[ ! -x "$interpreter" ]]; then
       print_info "podman-compose at $resolved points to missing interpreter: $interpreter"
       return 1


### PR DESCRIPTION
The main executable script /usr/bin/podman-compose from Package `podman-compose.noarch 1.5.0-1.1.fc42` in Fedora42 Repos, contains a space in front of the interpreter path.

```bash
#! /usr/bin/python3 -sP
```
With this, the old line of code in setup.py removed the content of the variable $interpreter completely, because of the leading space:
```bash
interpreter=${interpreter%% *}
```

This new line fixes things:
```bash
read -r interpreter _ <<<"${interpreter}"
```

```bash
podman-compose --version
podman-compose version 1.5.0
podman version 5.7.1
```