### PR TITLE
restrict vnc/rdp access to localhost

### DIFF
--- a/config/compose.yaml.default
+++ b/config/compose.yaml.default
@@ -35,9 +35,9 @@ services:
       ARGUMENTS: "-cpu host,arch_capabilities=off" # needed for Win 11
       NETWORK: "slirp" # User-mode networking may break otherwise      
     ports:
-      - 8006:8006 # Map '8006' on Linux host to '8006' on Windows VM --> For VNC Web Interface @ http://127.0.0.1:8006
-      - 3388:3389/tcp # Map '3388' on Linux host to '3389' on Windows VM --> For Remote Desktop Protocol (RDP). 3388 is chosen to avoid conflict with the standard RDP and WinApps port 3389, in case there are two VMs running.
-      - 3388:3389/udp # Map '3388' on Linux host to '3389' on Windows VM --> For Remote Desktop Protocol (RDP). 3388 is chosen to avoid conflict with the standard RDP and WinApps port 3389, in case there are two VMs running.
+      - 127.0.0.1:8006:8006 # Map '8006' on Linux host to '8006' on Windows VM --> For VNC Web Interface @ http://127.0.0.1:8006
+      - 127.0.0.1:3388:3389/tcp # Map '3388' on Linux host to '3389' on Windows VM --> For Remote Desktop Protocol (RDP). 3388 is chosen to avoid conflict with the standard RDP and WinApps port 3389, in case there are two VMs running.
+      - 127.0.0.1:3388:3389/udp # Map '3388' on Linux host to '3389' on Windows VM --> For Remote Desktop Protocol (RDP). 3388 is chosen to avoid conflict with the standard RDP and WinApps port 3389, in case there are two VMs running.
     cap_add:
       - NET_ADMIN  # Add network permission
     stop_grace_period: 120s # Wait 120 seconds before sending SIGTERM when attempting to shut down the Windows VM.


### PR DESCRIPTION
This chance modifies the docker port directive, to restrict the port to localhost.

Addresses #105 