### PR TITLE
Fix RAM detection failing on non-English locales

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -315,7 +315,7 @@ function check_requirements() {
     print_info "Checking minimum RAM"
     local ram_line=$((LINENO + 1))
     REQUIRED_RAM=7 # 8 GB shows up as 7.6 GiB so best to just set the threshold to 7 in this script
-    AVAILABLE_RAM="$(free -b | awk '/^Mem:/{print int($2/1024/1024/1024)}')"
+    AVAILABLE_RAM="$(LC_ALL=C free -b | awk '/^Mem:/{print int($2/1024/1024/1024)}')"
     if [ "$AVAILABLE_RAM" -lt "$REQUIRED_RAM" ]; then
         exit_with_error "Insufficient RAM. Required: ${REQUIRED_RAM}GB, Available: ${AVAILABLE_RAM}GB. \
     Please upgrade your system memory to at least ${REQUIRED_RAM}GB.


### PR DESCRIPTION
'free' outputs localized column headers (e.g. 'Speicher:' instead of 'Mem:' on German locales), causing the awk pattern to never match and AVAILABLE_RAM to be empty. This silently skips the RAM check instead of properly validating it. Force free to use the C locale so the column header is always in English."